### PR TITLE
Call pmproaw_init() to ensure API library is loaded

### DIFF
--- a/pmpro-aweber.php
+++ b/pmpro-aweber.php
@@ -75,6 +75,9 @@ function pmproaw_getAccount($force = false)
 {
 	global $pmproaw_aweber_api, $pmproaw_aweber_account;	
 	
+	// Ensure that the API library has been loaded
+	pmproaw_init();
+	
 	if(empty($force) && empty($pmproaw_aweber_account)) {		
 		$options = get_option("pmproaw_options");
 		


### PR DESCRIPTION
In some cases, such as during admin-ajax.php processing, it's possible for pmproaw_getAccount() to get called without the API libraries being loaded, which results in a fatal error because the `AWeberAPI` class has not been loaded.

We've seen this occur when customers are using PMP, EDD, and our respective Aweber add-ons at the same time.