### PR TITLE
Email updates now update correct subscriber.

### DIFF
--- a/pmpro-aweber.php
+++ b/pmpro-aweber.php
@@ -375,14 +375,16 @@ function pmproaw_profile_update($user_id, $old_user_data)
 					//change email
 					foreach($found_subscribers as $subscriber)
 					{
-						$subscriber->email = $new_user_data->user_email;
-						$subscriber->save();							
+						if ( strtolower( $old_user_data->user_email ) === strtolower( $subscriber->email ) ) {
+							$subscriber->email = $new_user_data->user_email;
+							$subscriber->save();
+						}
 					}
 				}
 			}
 		}
 		catch(AWeberAPIException $exc) {
-			//just catching errors to hide them from users					
+			//just catching errors to hide them from users
 		}
 	}
 }

--- a/pmpro-aweber.php
+++ b/pmpro-aweber.php
@@ -369,16 +369,16 @@ function pmproaw_profile_update($user_id, $old_user_data)
 					//find subscriber
 					$subscribers = $aw_list->subscribers;
 				
-					$params = array('status' => 'subscribed');
+					$params = array(
+						'status' => 'subscribed',
+						'email'  => $old_user_data->user_email,
+					);
 					$found_subscribers = $subscribers->find($params);
-				
-					//change email
-					foreach($found_subscribers as $subscriber)
-					{
-						if ( strtolower( $old_user_data->user_email ) === strtolower( $subscriber->email ) ) {
-							$subscriber->email = $new_user_data->user_email;
-							$subscriber->save();
-						}
+					if ( count( $found_subscribers ) ) {
+						// Subscriber found. Change email.
+						$subscriber = $found_subscribers[0];
+						$subscriber->email = $new_user_data->user_email;
+						$subscriber->save();
 					}
 				}
 			}


### PR DESCRIPTION
Resolves #18 

Previously, if a user changed their email address in PMPro, it would always update the email address of the oldest AWeber subscriber. Now updates the subscriber with their previous email address.