### PR TITLE
Update a User if exist when subscribe

### DIFF
--- a/pmpro-aweber.php
+++ b/pmpro-aweber.php
@@ -332,7 +332,7 @@ function pmproaw_subscribe($list_id, $list_user)
 		$new_subscriber = $subscribers->create(array(
 				'email' => $list_user->user_email,
 				'name' => trim($list_user->first_name . " " . $list_user->last_name),
-		                'update_existing' => "true",
+		                'update_existing' => 'true',
 				'status' => 'subscribed',
 		));
 	}
@@ -342,7 +342,7 @@ function pmproaw_subscribe($list_id, $list_user)
 		$new_subscriber = $subscribers->create(array(
 				'email' => $list_user->user_email,
 				'name' => trim($list_user->first_name . " " . $list_user->last_name),
-                                'update_existing' => "true",
+                                'update_existing' => 'true',
                                 'status' => 'subscribed',
                                 'custom_fields' => $custom_fields,
 		));

--- a/pmpro-aweber.php
+++ b/pmpro-aweber.php
@@ -331,7 +331,10 @@ function pmproaw_subscribe($list_id, $list_user)
 	{
 		$new_subscriber = $subscribers->create(array(
 				'email' => $list_user->user_email,
-				'name' => trim($list_user->first_name . " " . $list_user->last_name)));
+				'name' => trim($list_user->first_name . " " . $list_user->last_name),
+		                'update_existing' => "true",
+				'status' => 'subscribed',
+		));
 	}
 	
 	else
@@ -339,7 +342,10 @@ function pmproaw_subscribe($list_id, $list_user)
 		$new_subscriber = $subscribers->create(array(
 				'email' => $list_user->user_email,
 				'name' => trim($list_user->first_name . " " . $list_user->last_name),
-				'custom_fields' => $custom_fields));
+                                'update_existing' => "true",
+                                'status' => 'subscribed',
+                                'custom_fields' => $custom_fields,
+		));
 	}
 }
 


### PR DESCRIPTION
Currently, if a user already exist (even unsubscribed) in a list then the create function fails because it tries to create new user.  The Weber API has an "update_existing" option in the Subscriber API, so why not use it?