### PR TITLE
Fatal error on authenticating API calls fixed

### DIFF
--- a/includes/aweber_api/curl_response.php
+++ b/includes/aweber_api/curl_response.php
@@ -26,6 +26,11 @@ class CurlResponse
         # Extract the version and status from the first header
         $version_and_status = array_shift($headers);
         preg_match('#HTTP/(\d\.\d)\s(\d\d\d)\s(.*)#', $version_and_status, $matches);
+        
+        if( empty( $matches ) ) {
+            return;
+        }
+
         $this->headers['Http-Version'] = $matches[1];
         $this->headers['Status-Code'] = $matches[2];
         $this->headers['Status'] = $matches[2].' '.$matches[3];

--- a/includes/aweber_api/oauth_application.php
+++ b/includes/aweber_api/oauth_application.php
@@ -473,7 +473,7 @@ class OAuthApplication implements AWeberOAuthAdapter {
             echo "</pre>";
         }
 
-        if (!$resp) {
+        if (!$resp || empty( $resp->body ) ) {
             $msg  = 'Unable to connect to the AWeber API.  (' . $this->error . ')';
             $error = array('message' => $msg, 'type' => 'APIUnreachableError',
                            'documentation_url' => 'https://labs.aweber.com/docs/troubleshooting');

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Paid Memberships Pro - AWeber Add On ===
 Contributors: strangerstudios
 Tags: pmpro, paid memberships pro, aweber, email marketing
-Requires at least: 4
-Tested up to: 5.9
+Requires at least: 5.2
+Tested up to: 6.2
 Stable tag: 1.3.2
 
 Add users and members to AWeber lists based on their membership level.

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Paid Memberships Pro - AWeber Add On ===
 Contributors: strangerstudios
 Tags: pmpro, paid memberships pro, aweber, email marketing
-Requires at least: 5.2
-Tested up to: 6.2
+Requires at least: 4
+Tested up to: 5.9
 Stable tag: 1.3.2
 
 Add users and members to AWeber lists based on their membership level.


### PR DESCRIPTION
The AWeber API seems to fail when making calls from a local environment. 

This results in a fatal error because an unexpected response is returned - you then can't access the rest of the Aweber settings of the Add On. 

Steps to replicate: 
1. Go to the Aweber Settings and connect your account. 
2. Paste the auth key and save. If local, it should fail but give an error. If live, it should authenticate correctly